### PR TITLE
add support for iproute2 using jq

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@ Shows the network bandwidth in the status line.
 
 ## Installation
 ### Requirements
-* awk (GNU awk)
-* netstat
+* awk (GNU awk) and netstat (macOS and older Linux)
+* jq and iproute2 (newer Linux)
 * numfmt
 
 macOS: `brew install gawk coreutils`
 
-Linux: `apt-get install gawk net-tools coreutils`
+Older Linux: `apt-get install gawk net-tools coreutils`
+
+Newer Linux: `apt-get install jq coreutils`
 
 ### With Tmux Plugin Manager
 Add the plugin in `.tmux.conf`:

--- a/scripts/network-bandwidth.sh
+++ b/scripts/network-bandwidth.sh
@@ -21,11 +21,15 @@ get_bandwidth_for_osx() {
 }
 
 get_bandwidth_for_linux() {
-  netstat -ie | awk '
-    match($0, /RX([[:space:]]packets[[:space:]][[:digit:]]+)?[[:space:]]+bytes[:[:space:]]([[:digit:]]+)/, rx) { rx_sum+=rx[2]; }
-    match($0, /TX([[:space:]]packets[[:space:]][[:digit:]]+)?[[:space:]]+bytes[:[:space:]]([[:digit:]]+)/, tx) { tx_sum+=tx[2]; }
-    END { print rx_sum, tx_sum }
-  '
+  if which ip &> /dev/null; then
+    ip -s -json link | jq -rc '[(map(.stats64.rx.bytes) | add), (map(.stats64.tx.bytes) | add)] | .[]'
+  elif which netstat &> /dev/null; then
+    netstat -ie | awk '
+      match($0, /RX([[:space:]]packets[[:space:]][[:digit:]]+)?[[:space:]]+bytes[:[:space:]]([[:digit:]]+)/, rx) { rx_sum+=rx[2]; }
+      match($0, /TX([[:space:]]packets[[:space:]][[:digit:]]+)?[[:space:]]+bytes[:[:space:]]([[:digit:]]+)/, tx) { tx_sum+=tx[2]; }
+      END { print rx_sum, tx_sum }
+    '
+  fi
 }
 
 get_bandwidth() {


### PR DESCRIPTION
From the [netstat man page](https://linux.die.net/man/8/netstat):

> This program is obsolete. Replacement for netstat is ss. Replacement for netstat -r is ip route. Replacement for netstat -i is ip -s link. Replacement for netstat -g is ip maddr.

On my openSUSE Tumbleweed installation, `netstat` is part of the `net-tools-deprecated` package, which is not installed by default. So, I added support for the iproute2 set of tools.

A single run of `ip -s link` produces this output:

```
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    RX: bytes  packets  errors  dropped overrun mcast   
    4076       50       0       0       0       0       
    TX: bytes  packets  errors  dropped carrier collsns 
    4076       50       0       0       0       0       
2: enp34s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP mode DEFAULT group default qlen 1000
    link/ether 00:d8:61:fd:51:b7 brd ff:ff:ff:ff:ff:ff
    RX: bytes  packets  errors  dropped overrun mcast   
    4364847108 5157895  0       0       0       9117    
    TX: bytes  packets  errors  dropped carrier collsns 
    1522143739 3113517  0       0       0       0       
```

I have no experience with awk, but I'm assuming this is a different format than netstat provides, since manually running the contents of `scripts/network-bandwidth.sh` `get_bandwidth_for_linux` but replacing `netstat -ie` for `ip -s link` produces empty output.

Through some cludging around, I was able to determine that the following will process the information from iproute2 correctly. This uses `jq` instead of `awk`, since `ip` has the `-json` flag:

```sh
ip -s -json link | jq -rc '[(map(.stats64.rx.bytes) | add), (map(.stats64.tx.bytes) | add)] | .[]'
```